### PR TITLE
お気に入り問題から出題するシステムの構築

### DIFF
--- a/src/app/models/setting.rb
+++ b/src/app/models/setting.rb
@@ -1,7 +1,7 @@
 class Setting < ApplicationRecord
   enum :letter_kind, { jiantizi: Constants.letter_kind.jiantizi, fantizi: Constants.letter_kind.fantizi }, prefix: true
   enum :test_format, { chengyu: 0, mean: 1 }, prefix: true
-  enum :test_kind, { default: 0, mistake: 1 }, prefix: true
+  enum :test_kind, { default: 0, mistake: 1, favorite: 2 }, prefix: true
 
   belongs_to :user
 end

--- a/src/app/views/settings/edit.html.erb
+++ b/src/app/views/settings/edit.html.erb
@@ -45,7 +45,7 @@
       <%= "checked" if Setting.test_kinds[current_user.setting.test_kind] == Constants.test_kind.default %>
       value=<%= Constants.test_kind.default %> >
     <label class="form-check-label" for="flexRadioKindDefault">
-      全ての問題から答える
+      全ての問題から出題する
     </label>
   </div>
   <div class="form-check">
@@ -53,9 +53,18 @@
       <%= "checked" if Setting.test_kinds[current_user.setting.test_kind] == Constants.test_kind.mistake %>
       value=<%= Constants.test_kind.mistake %> >
     <label class="form-check-label" for="flexRadioKindMistake">
-      自分の間違った問題から答える
+      自分の間違った問題から出題する
     </label>
   </div>
+  <div class="form-check">
+    <input class="form-check-input" type="radio" name="test_kind" id="flexRadioKindFavorite"
+      <%= "checked" if Setting.test_kinds[current_user.setting.test_kind] == Constants.test_kind.favorite %>
+      value=<%= Constants.test_kind.favorite %> >
+    <label class="form-check-label" for="flexRadioKindFavorite">
+      お気に入り問題から出題する
+    </label>
+  </div>
+
   <button type="submit" class="btn btn-primary">変更する</button>
 
 <% end %>

--- a/src/app/views/shared/_test_format_change.html.erb
+++ b/src/app/views/shared/_test_format_change.html.erb
@@ -5,6 +5,8 @@
       全ての問題から出題する<br />
     <% when Constants.test_kind.mistake then %>
     過去間違えた問題から出題する<br />
+    <% when Constants.test_kind.favorite then %>
+    お気に入り問題から出題する<br />
   <% end %>
 <% else %>
   ログインすると回答記録が保存され、間違った問題を復習できるようになります。<br />

--- a/src/config/locales/ja.yml
+++ b/src/config/locales/ja.yml
@@ -8,6 +8,7 @@ ja:
         password: "パスワード"
         password_confirmation: "確認用パスワード"
         remember_me: "ログインを記憶"
+        role: "権限"
       setting:
         user: "ユーザid"
         letter_kind: "字体"
@@ -28,16 +29,23 @@ ja:
         user: "ユーザid"
         question: "問題id"
         test_format: "出題形式"
+        test_kind: "出題設定"
         correct: "正解したか"
       synonym:
         question: "類義語その１"
         question_another_id: "類義語その２"
+      bookmark:
+        user: "ユーザid"
+        question: "問題id"
+        favorite: "お気に入りフラグ"
+        known: "既知リストフラグ"
     models:
       user: "ユーザ"
       setting: "ユーザ設定"
       question: "問題"
       response: "回答"
       synonym: "類義語"
+      bookmark: "ブックマーク"
   # enum_help
   enums:
     user:
@@ -48,6 +56,17 @@ ja:
       letter_kind:
         jiantizi: '簡体字'
         fantizi: '繁体字'
+      test_format:
+        chengyu: '意味→成語'
+        mean: '成語→意味'
+        all: 'その他'
+      test_kind:
+        default: 'デフォルト'
+        mistake: '誤答から'
+        favorite: 'favから'
+      bookmark_flg:
+        favorite: 'お気に入り'
+        known: '既知'
     question:
       source:
         default: 'その他'

--- a/src/config/settings.yml
+++ b/src/config/settings.yml
@@ -14,6 +14,7 @@ test_format:
 test_kind:
   default: 0
   mistake: 1
+  favorite: 2
 bookmark_flg:
   favorite: 0
   known: 1


### PR DESCRIPTION
お気に入りとしてブックマークにした問題からのみ出題する
・お気に入りになっている問題が１問も無いときのエラー制御も済
・日本語化関連も済