### PR TITLE
各辞書のリンクを成語詳細ページに貼る

### DIFF
--- a/src/app/views/questions/show.html.erb
+++ b/src/app/views/questions/show.html.erb
@@ -45,6 +45,15 @@
       </td>
     </tr>
     <tr>
+      <td class="text-end pe-3">辞書</td>
+      <td>
+        <%= link_to 'Weblio日中中日辞典', "https://cjjc.weblio.jp/content/#{URI.encode_www_form_component(@question.chengyu_jianti)}", target: "_blank" %><br />
+        <%= link_to '漢典', "https://www.zdic.net/hans/#{URI.encode_www_form_component(@question.chengyu_jianti)}", target: "_blank" %><br />
+        <%= link_to '中華民國教育部 成語典', "https://dict.idioms.moe.edu.tw/idiomList.jsp?idiom=#{URI.encode_www_form_component(@question.chengyu_fanti)}", target: "_blank" %><br />
+        <%= link_to '萌典', "https://www.moedict.tw/#{URI.encode_www_form_component(@question.chengyu_fanti)}", target: "_blank" %>
+      </td>
+    </tr>
+    <tr>
       <td></td>
       <td>
         <%= render partial: "shared/favorite_button", locals: { question: @question }%>


### PR DESCRIPTION
成語詳細ページに
・Weblio日中中日辞典
・漢典
・中華民國教育部 成語典
・萌典
へのリンクを自動生成して貼る

close #95