### PR TITLE
類義語の検索判定が、類義語情報を複数持っていなかったときに対応していなかったので修正

### DIFF
--- a/src/app/models/synonym.rb
+++ b/src/app/models/synonym.rb
@@ -5,12 +5,12 @@ class Synonym < ApplicationRecord
   # 同義語チェック trueで判定OK(見つからなかった)
   def self.same_check(id_a, id_b)
     # synonymを全検索
-    tmp = Synonym.where(question_id: id_a).where(question_another_id: id_b)
+    tmp = Synonym.where("question_id LIKE ?", "%#{id_a}%").where("question_another_id LIKE ?", "%#{id_b}%")
     # tmpがnilじゃない＝見つかったらならNG
     return false if tmp.present?
 
     # synonymをidを入れ替えて全検索
-    tmp = Synonym.where(question_id: id_b).where(question_another_id: id_a)
+    tmp = Synonym.where("question_id LIKE ?", "%#{id_b}%").where("question_another_id LIKE ?", "%#{id_a}%")
     # tmpがnilならOKなのだから
     return false if tmp.present?
 


### PR DESCRIPTION
類義語の検索判定を完全一致ではなく部分判定処理に変えることで、類義語情報を複数持っていたとしても問題なく処理が行えるようにする
部分検索とすれば、区切り文字に関して考えなくてよいので、この実装方法とする